### PR TITLE
install multiple kubectl versions

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -126,11 +126,17 @@ kops_version: 1.9.0  ## ref: https://github.com/kubernetes/kops/releases
 
 ## kubectl
 kubectl_install_path: /usr/local/bin/kubectl
-kubectl_release_checksum: c73284421dac351a800442d6424b45ce62921baf359f8fe93a7b845341d59bf3
+kubectl_release_checksums: 
+  - b9f6bf64706a0ca5f1ebb9977fc7dd155b19881985a6b116a65db5f361fbc703
+  - 04b4f123f5eac36ce4bd1e833a1bb6ee1477aa360118da5c33255feefcf8d669
+  - 325fa3ebc2160f9479ec1b8ac089fe9bf4dd216a56eb97da661b6dcf6902aa13
 kubectl_release_checksum_type: sha256
 kubectl_release_url_base: https://storage.googleapis.com/kubernetes-release/release
 kubectl_release_url_suffix: bin/linux/amd64/kubectl
-kubectl_version: v1.10.0-rc.1  # ref: https://github.com/kubernetes/kubernetes/releases
+kubectl_versions:  # ref: https://github.com/kubernetes/kubernetes/releases
+  - v1.11.2
+  - v1.10.6
+  - v1.9.10
 
 ## mc (minio client)
 mc_install_path: /usr/local/bin/mc

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -244,10 +244,21 @@
   tags:
     - kubectl
   get_url:
-    url: "{{ kubectl_release_url_base }}/{{ kubectl_version }}/{{ kubectl_release_url_suffix }}"
-    dest: "{{ kubectl_install_path }}"
-    checksum: "{{ kubectl_release_checksum_type }}:{{ kubectl_release_checksum }}"
+    url: "{{ kubectl_release_url_base }}/{{ item.0 }}/{{ kubectl_release_url_suffix }}"
+    dest: "{{ kubectl_install_path }}_{{ item.0 }}"
+    checksum: "{{ kubectl_release_checksum_type }}:{{ item.1 }}"
     mode: 0755
+  with_together:
+    - "{{ kubectl_versions }}"
+    - "{{ kubectl_release_checksums }}"
+
+- name: kubectl | Create symlink to newest version.
+  tags:
+    - kubectl
+  file:
+    src: "{{ kubectl_install_path }}_{{ kubectl_versions[0] }}"
+    dest: "{{ kubectl_install_path }}"
+    state: link
 
 - name: minikube | Install binary release.
   tags:


### PR DESCRIPTION
If this is accepted then by default `/usr/local/bin/kubectl` will be a symlink to the newest `kubectl` and it will allow for dynamic change of symlink with `direnv` based on the cluster setup.

fixes https://github.com/cisco-sso/ansible-role-k8s-devkit/issues

ptal @marsavela @simt2 @darkyat @dcwangmit01 @josdotso 