### PR TITLE
Update pyvmomi version to 6.7.0.2018.9

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -190,7 +190,7 @@ pip3_packages:
   - name: openshift
     version: 0.5.0
   - name: pyvmomi
-    version: 6.7.0
+    version: 6.7.0.2018.9
 
 ## terraform
 terraform_install_path: /usr/local/bin/terraform


### PR DESCRIPTION
Current pyvmomi version 6.7.0 is not available and the role fails. This updates it to the latest 6.7.0.2018.9