### PR TITLE
Update Terraform version to 0.11.8

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -194,11 +194,11 @@ pip3_packages:
 
 ## terraform
 terraform_install_path: /usr/local/bin/terraform
-terraform_release_checksum: 6b8ce67647a59b2a3f70199c304abca0ddec0e49fd060944c26f666298e23418
+terraform_release_checksum: 84ccfb8e13b5fce63051294f787885b76a1fedef6bdbecf51c5e586c9e20c9b7
 terraform_release_checksum_type: sha256
 terraform_release_url_base: "https://releases.hashicorp.com/terraform"
 terraform_release_url_suffix: "terraform_{{ terraform_version }}_linux_amd64.zip"
-terraform_version: 0.11.7 ## ref: https://www.terraform.io/downloads.html
+terraform_version: 0.11.8 ## ref: https://www.terraform.io/downloads.html
 
 ## yum
 yum_packages:


### PR DESCRIPTION
Terraform update to 0.11.8

This has been tested with `ansible-playbook --limit=localhost --inventory-file=/vagrant/ansible/inventory /vagrant/ansible/main.yaml --tags terraform` and a cluster scale-out has been performed with said version.